### PR TITLE
macOS 27 Enhanced Siri cloud state repair

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 *.swp
 *.tmp
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ System Settings -> Privacy & Security -> 滑到底部 -> Allow
 把 countryd cache 固定為 US
 macOS 27+ 寫入 AppleInternalVariant.plist
 macOS 27+ 寫入 EnhancedSiriWaitlist FeatureFlags override
+macOS 27+ 修正 Enhanced Siri waitlist / CloudSubscriptionFeatures / GMS availability 狀態
+macOS 27+ 安裝常駐 Enhanced Siri repair LaunchDaemon，開機後與 cloud cache 被覆寫時自動補回
 保留 Siri Launchpad 圖標刷新
 保留 Location Services 裡 Siri 圖標 runtime patch
 保留 Siri / Safari 搜索 provider 切到 Google 並清理舊 Baidu 搜索
@@ -127,6 +129,8 @@ macOS 27+ 寫入 EnhancedSiriWaitlist FeatureFlags override
 --skip-web-search
 ```
 
+`--skip-launchdaemon` 會同時跳過開機載入 kext 的 loader 與 macOS 27+ Enhanced Siri repair daemon。
+
 ## 驗證
 
 ```bash
@@ -141,14 +145,25 @@ country-of-origin = USA
 CodexRegionSpoof loaded
 GREYMATTER / FOUNDATION_MODELS / PERSONAL_QA = 4
 SiriAvailability.desiredOrchestrationMode = 4
+ai.enhanced-siri canUse = true
+Enhanced Siri waitlist status = active
+Enhanced Siri unifiedReasons = []
 ```
 
 也可以看：
 
 ```bash
 sudo tail -100 /var/log/codex-region-spoof-loader.log
+sudo tail -100 /var/log/codex-enhanced-siri-repair.stdout.log
 ioreg -rd1 -c IOPlatformExpertDevice | grep -Ei 'region-info|country-of-origin'
 sudo kmutil showloaded | grep -Ei 'Codex|RegionSpoof'
+```
+
+如果重啟或聯網後又看到 `Siri Update in Progress` / 舊 Siri UI，可先看：
+
+```bash
+sudo tail -200 /var/log/codex-enhanced-siri-repair.stdout.log
+sudo tail -200 /var/log/codex-enhanced-siri-repair.stderr.log
 ```
 
 ## 成功後測試

--- a/enable_apple_intelligence_oneclick.sh
+++ b/enable_apple_intelligence_oneclick.sh
@@ -29,6 +29,11 @@ LOCAL_KEXT_BIN_B64="$LOCAL_KEXT/Contents/MacOS/CodexRegionSpoof.b64"
 LOADER_SCRIPT="/Library/Scripts/Codex/load-region-spoof.sh"
 LOADER_PLIST="/Library/LaunchDaemons/local.codex.region-spoof-loader.plist"
 SIRI_LOCATION_FIX_DIR="/Library/Scripts/Codex/SiriLocationIconFix"
+LOCAL_ENHANCED_SIRI_REPAIR_HELPER="$ROOT_DIR/tools/repair_enhanced_siri_state.py"
+ENHANCED_SIRI_REPAIR_HELPER="/Library/Scripts/Codex/repair_enhanced_siri_state.py"
+ENHANCED_SIRI_REPAIR_PLIST="/Library/LaunchDaemons/local.codex.enhanced-siri-repair.plist"
+ENHANCED_SIRI_REPAIR_STDOUT="/var/log/codex-enhanced-siri-repair.stdout.log"
+ENHANCED_SIRI_REPAIR_STDERR="/var/log/codex-enhanced-siri-repair.stderr.log"
 
 ELIGIBILITYD_PLIST="/private/var/db/eligibilityd/eligibility.plist"
 OS_ELIGIBILITY_PLIST="/private/var/db/os_eligibility/eligibility.plist"
@@ -51,6 +56,12 @@ FEATUREFLAGS_OVERRIDE_DIR="/Library/Preferences/FeatureFlags/Domain"
 GM_FEATUREFLAGS_OVERRIDE_PLIST="$FEATUREFLAGS_OVERRIDE_DIR/GenerativeModels.plist"
 SYSTEM_GM_FEATUREFLAGS_PLIST="/System/Library/FeatureFlags/Domain/GenerativeModels.plist"
 FEATUREFLAGS_BACKUP_BASE="/private/var/db/codex_featureflags_backup"
+AI_PLATFORM_PREFS_BASE="/private/var/db/AppleIntelligencePlatform"
+CLOUDSUB_CACHE_REL="Library/Preferences/com.apple.CloudSubscriptionFeatures.cache.plist"
+CLOUDSUB_WAITLIST_REL="Library/Preferences/com.apple.CloudSubscriptionFeatures.waitlist.plist"
+GMS_AVAILABILITY_REL="Library/Preferences/com.apple.gms.availability.plist"
+GLOBALPREFERENCES_BYHOST_REL="Library/Preferences/ByHost"
+ENHANCED_SIRI_OVERRIDE_BACKUP_REL="Library/Preferences/EnhancedSiriOverrideBackups"
 
 ELIGIBILITYD_DOMAINS=(
   OS_ELIGIBILITY_DOMAIN_GREYMATTER
@@ -106,7 +117,7 @@ Options:
   --uninstall          Alias for uninstall.
   --dry-run            With uninstall, show actions without changing files.
   --skip-kext          Do not install/load CodexRegionSpoof.kext this run.
-  --skip-launchdaemon  Do not install/update the boot-time loader.
+  --skip-launchdaemon  Do not install/update background LaunchDaemons.
   --skip-eligibility   Do not patch eligibility plist domains.
   --skip-sae           Do not force Siri SAE orchestration preference.
   --skip-location-ip   Do not write GeoServices country cache.
@@ -117,7 +128,8 @@ Options:
   --skip-apple-internal
                        On macOS 27+, skip AppleInternalVariant.plist.
   --skip-macos27-siri-ai
-                       On macOS 27+, skip EnhancedSiriWaitlist override.
+                       On macOS 27+, skip Enhanced Siri waitlist/cache/GMS
+                       overrides.
   --skip-siri-location-icon
                        Do not install/apply the Location Services Siri icon
                        runtime patch.
@@ -252,6 +264,11 @@ console_uid() {
   /usr/bin/id -u "$user" 2>/dev/null || true
 }
 
+console_gid() {
+  local user="$1"
+  /usr/bin/id -g "$user" 2>/dev/null || true
+}
+
 console_home() {
   local user="$1"
   /usr/bin/dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null |
@@ -260,9 +277,11 @@ console_home() {
 
 CONSOLE_USER="$(console_user || true)"
 CONSOLE_UID=""
+CONSOLE_GID=""
 CONSOLE_HOME=""
 if [[ -n "$CONSOLE_USER" ]]; then
   CONSOLE_UID="$(console_uid "$CONSOLE_USER")"
+  CONSOLE_GID="$(console_gid "$CONSOLE_USER")"
   CONSOLE_HOME="$(console_home "$CONSOLE_USER")"
 fi
 [[ -n "$CONSOLE_HOME" ]] || CONSOLE_HOME="/var/root"
@@ -487,6 +506,103 @@ print_siri_state() {
   fi
 }
 
+print_enhanced_siri_state() {
+  section "Enhanced Siri cloud state"
+  if [[ -z "$CONSOLE_USER" || -z "$CONSOLE_UID" ]]; then
+    warn "No console user found; skipping Enhanced Siri cloud diagnostics"
+    return 0
+  fi
+
+  local cache_plist="$CONSOLE_HOME/$CLOUDSUB_CACHE_REL"
+  local waitlist_plist="$CONSOLE_HOME/$CLOUDSUB_WAITLIST_REL"
+  local user_gms_plist="$CONSOLE_HOME/$GMS_AVAILABILITY_REL"
+  local platform_gms_plist="$AI_PLATFORM_PREFS_BASE/$CONSOLE_UID/Library/Preferences/com.apple.gms.availability.plist"
+  local byhost_dir="$CONSOLE_HOME/$GLOBALPREFERENCES_BYHOST_REL"
+
+  /usr/bin/python3 - "$cache_plist" "$waitlist_plist" "$user_gms_plist" "$platform_gms_plist" "$GM_FEATUREFLAGS_OVERRIDE_PLIST" "$byhost_dir" <<'PY'
+import json
+import pathlib
+import plistlib
+import sys
+
+cache_path, waitlist_path, user_gms_path, platform_gms_path, featureflags_path, byhost_dir = sys.argv[1:7]
+
+def load_plist(path):
+    p = pathlib.Path(path)
+    if not p.exists():
+        return None
+    with p.open("rb") as fh:
+        return plistlib.load(fh)
+
+def decode_blob(raw):
+    if isinstance(raw, (bytes, bytearray)):
+        for parser in (plistlib.loads, lambda b: json.loads(b.decode("utf-8"))):
+            try:
+                return parser(raw)
+            except Exception:
+                pass
+    return raw
+
+cache = load_plist(cache_path) or {}
+waitlist = load_plist(waitlist_path) or {}
+user_gms = load_plist(user_gms_path) or {}
+platform_gms = load_plist(platform_gms_path) or {}
+featureflags = load_plist(featureflags_path) or {}
+if not isinstance(cache, dict):
+    cache = {}
+if not isinstance(waitlist, dict):
+    waitlist = {}
+if not isinstance(user_gms, dict):
+    user_gms = {}
+if not isinstance(platform_gms, dict):
+    platform_gms = {}
+if not isinstance(featureflags, dict):
+    featureflags = {}
+
+cache_entry = decode_blob(cache.get("ai.enhanced-siri")) if isinstance(cache, dict) else None
+cache_value = cache_entry.get("value", {}) if isinstance(cache_entry, dict) else {}
+print(f"cache ai.enhanced-siri canUse: {cache_value.get('canUse')!r}")
+print(f"cache fetched: {cache_entry.get('fetched')!r}" if isinstance(cache_entry, dict) else "cache fetched: None")
+
+waitlist_results = decode_blob(waitlist.get("waitlistResults", b"[]")) if isinstance(waitlist, dict) else []
+status = None
+if isinstance(waitlist_results, list):
+    for item in waitlist_results:
+        value = item.get("value", {}) if isinstance(item, dict) else {}
+        if "ai.enhanced-siri" in (value.get("featureIDs") or []):
+            status = value.get("status")
+            break
+print(f"waitlist status: {status!r}")
+
+print(f"user unifiedReasons: {decode_blob(user_gms.get('com.apple.gms.enhancedSiri.unifiedReasons'))!r}")
+print(f"platform denied use cases: {platform_gms.get('com.apple.gms.availability.accessNotGrantedUseCases')!r}")
+print(f"platform unifiedReasons: {decode_blob(platform_gms.get('com.apple.gms.availability.unifiedReasons'))!r}")
+
+byhost_states = []
+for plist_path in sorted(pathlib.Path(byhost_dir).glob(".GlobalPreferences.*.plist")):
+    data = load_plist(plist_path) or {}
+    byhost_states.append(
+        (
+            plist_path.name,
+            data.get("com.apple.gms.enhancedSiri.availability"),
+            data.get("com.apple.gms.enhancedSiri.reasons"),
+        )
+    )
+if byhost_states:
+    for name, availability, reasons in byhost_states:
+        print(f"{name}: availability={availability!r} reasons={reasons!r}")
+else:
+    print("ByHost GlobalPreferences: none found")
+
+print(
+    "FeatureFlags EnhancedSiriWaitlist: "
+    f"{featureflags.get('EnhancedSiriWaitlist', {}).get('Enabled')!r}"
+)
+PY
+  kv "repair helper installed" "$(yes_no test -x "$ENHANCED_SIRI_REPAIR_HELPER")"
+  kv "repair daemon installed" "$(yes_no test -f "$ENHANCED_SIRI_REPAIR_PLIST")"
+}
+
 preflight_install() {
   section "Environment check"
   kv "Workspace" "$ROOT_DIR"
@@ -681,6 +797,13 @@ PY
   /bin/chmod 644 "$SIRI_LOCATION_FIX_DIR/patch_locationd_skip_assistantd_association_lldb.py"
 }
 
+install_enhanced_siri_repair_helper() {
+  [[ -f "$LOCAL_ENHANCED_SIRI_REPAIR_HELPER" ]] || die "Missing helper: $LOCAL_ENHANCED_SIRI_REPAIR_HELPER"
+  /bin/mkdir -p "$(dirname "$ENHANCED_SIRI_REPAIR_HELPER")"
+  /usr/bin/install -m 755 "$LOCAL_ENHANCED_SIRI_REPAIR_HELPER" "$ENHANCED_SIRI_REPAIR_HELPER"
+  /usr/sbin/chown root:wheel "$ENHANCED_SIRI_REPAIR_HELPER"
+}
+
 clean_siri_location_rows() {
   local clients_plist="/var/db/locationd/clients.plist"
   /usr/bin/python3 - "$clients_plist" <<'PY'
@@ -738,6 +861,37 @@ for key in remove_keys:
 PY
 }
 
+console_launchagent_label() {
+  case "$1" in
+    assistantd) echo "com.apple.assistantd" ;;
+    generativeexperiencesd) echo "com.apple.generativeexperiencesd" ;;
+    *) return 1 ;;
+  esac
+}
+
+console_launchagent_plist() {
+  case "$1" in
+    assistantd) echo "/System/Library/LaunchAgents/com.apple.assistantd.plist" ;;
+    generativeexperiencesd) echo "/System/Library/LaunchAgents/com.apple.generativeexperiencesd.plist" ;;
+    *) return 1 ;;
+  esac
+}
+
+kickstart_console_launchagent() {
+  local service="$1" label plist
+  [[ -n "$CONSOLE_UID" ]] || return 0
+  label="$(console_launchagent_label "$service")" || return 0
+  plist="$(console_launchagent_plist "$service")" || return 0
+  /bin/launchctl bootstrap "gui/$CONSOLE_UID" "$plist" 2>/dev/null || true
+  /bin/launchctl kickstart -k "gui/$CONSOLE_UID/$label" 2>/dev/null || true
+}
+
+restart_console_ai_agents() {
+  [[ -n "$CONSOLE_UID" ]] || return 0
+  kickstart_console_launchagent generativeexperiencesd
+  kickstart_console_launchagent assistantd
+}
+
 apply_siri_location_icon_runtime_fix_now() {
   section "Location Services Siri icon runtime patch"
   local patch="$SIRI_LOCATION_FIX_DIR/patch_locationd_skip_assistantd_association_lldb.py"
@@ -760,10 +914,7 @@ apply_siri_location_icon_runtime_fix_now() {
     warn "locationd did not restart before patch attempt"
   fi
 
-  if [[ -n "$CONSOLE_UID" ]]; then
-    /bin/launchctl bootstrap "gui/$CONSOLE_UID" /System/Library/LaunchAgents/com.apple.assistantd.plist 2>/dev/null || true
-    /bin/launchctl kickstart -k "gui/$CONSOLE_UID/com.apple.assistantd" 2>/dev/null || true
-  fi
+  restart_console_ai_agents
   clean_siri_location_rows || true
   as_console_user /usr/bin/killall "System Settings" SecurityPrivacyExtension cfprefsd iconservicesagent IconServicesAgent 2>/dev/null || true
 }
@@ -934,7 +1085,7 @@ apply_siri_location_icon_fix() {
   apply_siri_location_icon_fix
 
   echo "refreshing region and AI daemons"
-  /usr/bin/killall eligibilityd generativeexperiencesd modelcatalogd modelmanagerd countryd locationd geod routined 2>/dev/null || true
+  /usr/bin/killall eligibilityd generativeexperiencesd modelcatalogd modelmanagerd assistantd countryd locationd geod routined 2>/dev/null || true
   /bin/launchctl kickstart -k system/com.apple.eligibilityd 2>/dev/null || true
   /bin/launchctl kickstart -k system/com.apple.modelcatalogd 2>/dev/null || true
   /bin/launchctl kickstart -k system/com.apple.modelmanagerd 2>/dev/null || true
@@ -980,6 +1131,72 @@ EOF
 
   ok "installed and started $LOADER_PLIST"
   log "Log: /var/log/codex-region-spoof-loader.log"
+}
+
+install_macos27_enhanced_siri_repair_launchdaemon() {
+  section "Install macOS 27 Enhanced Siri repair daemon"
+  local major
+  major="$(macos_major_version)"
+  if (( major < 27 )); then
+    log "macOS major version is $major; skipping Enhanced Siri repair daemon."
+    return 0
+  fi
+  if [[ -z "$CONSOLE_USER" || -z "$CONSOLE_UID" ]]; then
+    warn "No console user found; skipping Enhanced Siri repair daemon"
+    return 0
+  fi
+
+  install_enhanced_siri_repair_helper
+
+  local cache_plist="$CONSOLE_HOME/$CLOUDSUB_CACHE_REL"
+  local waitlist_plist="$CONSOLE_HOME/$CLOUDSUB_WAITLIST_REL"
+  local user_gms_plist="$CONSOLE_HOME/$GMS_AVAILABILITY_REL"
+  local platform_gms_plist="$AI_PLATFORM_PREFS_BASE/$CONSOLE_UID/Library/Preferences/com.apple.gms.availability.plist"
+
+  /bin/cat > "$ENHANCED_SIRI_REPAIR_PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>local.codex.enhanced-siri-repair</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/python3</string>
+    <string>$ENHANCED_SIRI_REPAIR_HELPER</string>
+    <string>--repair-if-needed</string>
+    <string>--quiet</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>120</integer>
+  <key>ThrottleInterval</key>
+  <integer>15</integer>
+  <key>WatchPaths</key>
+  <array>
+    <string>$cache_plist</string>
+    <string>$waitlist_plist</string>
+    <string>$user_gms_plist</string>
+    <string>$platform_gms_plist</string>
+  </array>
+  <key>StandardOutPath</key>
+  <string>$ENHANCED_SIRI_REPAIR_STDOUT</string>
+  <key>StandardErrorPath</key>
+  <string>$ENHANCED_SIRI_REPAIR_STDERR</string>
+</dict>
+</plist>
+EOF
+
+  /usr/sbin/chown root:wheel "$ENHANCED_SIRI_REPAIR_PLIST"
+  /bin/chmod 644 "$ENHANCED_SIRI_REPAIR_PLIST"
+
+  /bin/launchctl bootout system "$ENHANCED_SIRI_REPAIR_PLIST" 2>/dev/null || true
+  /bin/launchctl bootstrap system "$ENHANCED_SIRI_REPAIR_PLIST" 2>/dev/null || true
+  /bin/launchctl kickstart -k system/local.codex.enhanced-siri-repair 2>/dev/null || true
+
+  ok "installed and started $ENHANCED_SIRI_REPAIR_PLIST"
+  log "Logs: $ENHANCED_SIRI_REPAIR_STDOUT, $ENHANCED_SIRI_REPAIR_STDERR"
 }
 
 ensure_domain() {
@@ -1338,6 +1555,25 @@ PY
   ok "FeatureFlags override installed; backup: $backup_dir"
 }
 
+install_macos27_enhanced_siri_overrides() {
+  section "macOS 27 Enhanced Siri cloud + GMS overrides"
+  local major backup_dir
+  major="$(macos_major_version)"
+  if (( major < 27 )); then
+    log "macOS major version is $major; skipping macOS 27-only Enhanced Siri state repair."
+    return 0
+  fi
+  if [[ -z "$CONSOLE_USER" || -z "$CONSOLE_UID" || -z "$CONSOLE_GID" ]]; then
+    warn "No console user found; skipping user-scoped Enhanced Siri state repair"
+    return 0
+  fi
+
+  install_enhanced_siri_repair_helper
+  backup_dir="$CONSOLE_HOME/$ENHANCED_SIRI_OVERRIDE_BACKUP_REL/$(/bin/date +%Y%m%d-%H%M%S)"
+  /usr/bin/python3 "$ENHANCED_SIRI_REPAIR_HELPER" --repair-now --backup-root "$backup_dir"
+  ok "Enhanced Siri waitlist/cache and GMS overrides applied; backup: $backup_dir"
+}
+
 mirror_siri_availability_to_appleidsettings() {
   [[ -n "$CONSOLE_USER" ]] || return 0
   section "Mirror SiriAvailability to AppleIDSettings"
@@ -1483,11 +1719,16 @@ SWIFT
 
 refresh_ai_daemons() {
   section "Refresh AI daemons"
-  /usr/bin/killall eligibilityd generativeexperiencesd modelcatalogd modelmanagerd 2>/dev/null || true
+  /usr/bin/killall eligibilityd generativeexperiencesd modelcatalogd modelmanagerd assistantd 2>/dev/null || true
   /bin/launchctl kickstart -k system/com.apple.eligibilityd 2>/dev/null || true
   /bin/launchctl kickstart -k system/com.apple.modelcatalogd 2>/dev/null || true
   /bin/launchctl kickstart -k system/com.apple.modelmanagerd 2>/dev/null || true
-  [[ -n "$CONSOLE_USER" ]] && as_console_user /usr/bin/killall "System Settings" SiriPreferenceExtension SiriNCService Siri cfprefsd 2>/dev/null || true
+  if [[ -n "$CONSOLE_USER" ]]; then
+    as_console_user /usr/bin/notifyutil -p com.apple.CloudSubscriptionFeature.Changed 2>/dev/null || true
+    as_console_user /usr/bin/notifyutil -p com.apple.siri.orchestration.capabilities.didChange 2>/dev/null || true
+    as_console_user /usr/bin/killall "System Settings" SiriPreferenceExtension SiriNCService Siri cfprefsd 2>/dev/null || true
+  fi
+  restart_console_ai_agents
 }
 
 run_status() {
@@ -1503,6 +1744,7 @@ run_status() {
   print_country_state
   print_macos27_state
   print_siri_state
+  print_enhanced_siri_state
 }
 
 run_install() {
@@ -1517,6 +1759,8 @@ run_install() {
   [[ "$SKIP_COUNTRYD" == "0" ]] && force_countryd_us
   [[ "$SKIP_APPLE_INTERNAL" == "0" ]] && install_apple_internal_variant
   [[ "$SKIP_MACOS27_SIRI_AI" == "0" ]] && install_macos27_featureflag
+  [[ "$SKIP_MACOS27_SIRI_AI" == "0" ]] && install_macos27_enhanced_siri_overrides
+  [[ "$SKIP_MACOS27_SIRI_AI" == "0" && "$SKIP_LAUNCHDAEMON" == "0" ]] && install_macos27_enhanced_siri_repair_launchdaemon
   [[ "$SKIP_WEB_SEARCH" == "0" ]] && force_web_search_provider_google
   [[ "$SKIP_SIRI_LOCATION_ICON" == "0" ]] && apply_siri_location_icon_runtime_fix_now
   refresh_ai_daemons
@@ -1549,11 +1793,29 @@ backup_for_uninstall() {
     return 0
   fi
   /bin/mkdir -p "$BACKUP_ROOT"
-  for p in "$KEXT_DST" "$LOADER_SCRIPT" "$LOADER_PLIST" "$SIRI_LOCATION_FIX_DIR" "$ELIGIBILITYD_PLIST" "$OS_ELIGIBILITY_PLIST" "$COUNTRYD_PLIST" "$GEOSERVICES_DIRECT_STORE" "$GM_FEATUREFLAGS_OVERRIDE_PLIST"; do
+  for p in "$KEXT_DST" "$LOADER_SCRIPT" "$LOADER_PLIST" "$ENHANCED_SIRI_REPAIR_HELPER" "$ENHANCED_SIRI_REPAIR_PLIST" "$SIRI_LOCATION_FIX_DIR" "$ELIGIBILITYD_PLIST" "$OS_ELIGIBILITY_PLIST" "$COUNTRYD_PLIST" "$GEOSERVICES_DIRECT_STORE" "$GM_FEATUREFLAGS_OVERRIDE_PLIST"; do
     [[ -e "$p" ]] || continue
     /bin/mkdir -p "$BACKUP_ROOT$(dirname "$p")"
     /bin/cp -a "$p" "$BACKUP_ROOT$p" 2>/dev/null || true
   done
+  for p in \
+    "$CONSOLE_HOME/$CLOUDSUB_CACHE_REL" \
+    "$CONSOLE_HOME/$CLOUDSUB_WAITLIST_REL" \
+    "$CONSOLE_HOME/$GMS_AVAILABILITY_REL" \
+    "$AI_PLATFORM_PREFS_BASE/${CONSOLE_UID:-0}/Library/Preferences/com.apple.gms.availability.plist"
+  do
+    [[ -e "$p" ]] || continue
+    /bin/mkdir -p "$BACKUP_ROOT$(dirname "$p")"
+    /bin/cp -a "$p" "$BACKUP_ROOT$p" 2>/dev/null || true
+  done
+  if [[ -d "$CONSOLE_HOME/$GLOBALPREFERENCES_BYHOST_REL" ]]; then
+    local byhost_plist
+    for byhost_plist in "$CONSOLE_HOME/$GLOBALPREFERENCES_BYHOST_REL"/.GlobalPreferences.*.plist; do
+      [[ -e "$byhost_plist" ]] || continue
+      /bin/mkdir -p "$BACKUP_ROOT$(dirname "$byhost_plist")"
+      /bin/cp -a "$byhost_plist" "$BACKUP_ROOT$byhost_plist" 2>/dev/null || true
+    done
+  fi
   run_status > "$BACKUP_ROOT/status-before.txt" 2>&1 || true
   log "Backup: $BACKUP_ROOT"
 }
@@ -1594,7 +1856,8 @@ run_uninstall() {
   backup_for_uninstall
 
   do_or_print /bin/launchctl bootout system "$LOADER_PLIST" 2>/dev/null || true
-  do_or_print /bin/rm -f "$LOADER_PLIST" "$LOADER_SCRIPT"
+  do_or_print /bin/launchctl bootout system "$ENHANCED_SIRI_REPAIR_PLIST" 2>/dev/null || true
+  do_or_print /bin/rm -f "$LOADER_PLIST" "$LOADER_SCRIPT" "$ENHANCED_SIRI_REPAIR_PLIST" "$ENHANCED_SIRI_REPAIR_HELPER"
   do_or_print /bin/rm -rf "$SIRI_LOCATION_FIX_DIR"
 
   if [[ -d "$KEXT_DST" ]]; then
@@ -1617,7 +1880,7 @@ run_uninstall() {
     do_or_print as_console_user /usr/bin/defaults delete "$SIRI_DOMAIN" "$SIRI_KEY" 2>/dev/null || true
   fi
 
-  do_or_print /usr/bin/killall eligibilityd generativeexperiencesd modelcatalogd modelmanagerd countryd locationd 2>/dev/null || true
+  do_or_print /usr/bin/killall eligibilityd generativeexperiencesd modelcatalogd modelmanagerd assistantd countryd locationd 2>/dev/null || true
   run_status
 
   section "Next steps"

--- a/tools/repair_enhanced_siri_state.py
+++ b/tools/repair_enhanced_siri_state.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import copy
+import datetime as dt
+import fcntl
+import json
+import os
+import pathlib
+import plistlib
+import pwd
+import shutil
+import stat
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+
+CF_ABSOLUTE_EPOCH = 978307200.0
+AI_PLATFORM_PREFS_BASE = pathlib.Path("/private/var/db/AppleIntelligencePlatform")
+CLOUDSUB_CACHE_REL = pathlib.Path("Library/Preferences/com.apple.CloudSubscriptionFeatures.cache.plist")
+CLOUDSUB_WAITLIST_REL = pathlib.Path("Library/Preferences/com.apple.CloudSubscriptionFeatures.waitlist.plist")
+GMS_AVAILABILITY_REL = pathlib.Path("Library/Preferences/com.apple.gms.availability.plist")
+BYHOST_REL = pathlib.Path("Library/Preferences/ByHost")
+BACKUP_REL = pathlib.Path("Library/Preferences/EnhancedSiriOverrideBackups")
+LOCK_PATH = pathlib.Path("/private/tmp/codex-enhanced-siri-repair.lock")
+NOTIFY_NAMES = (
+    "com.apple.CloudSubscriptionFeature.Changed",
+    "com.apple.siri.orchestration.capabilities.didChange",
+)
+GUI_LAUNCH_AGENTS = (
+    ("com.apple.generativeexperiencesd", "/System/Library/LaunchAgents/com.apple.generativeexperiencesd.plist"),
+    ("com.apple.assistantd", "/System/Library/LaunchAgents/com.apple.assistantd.plist"),
+)
+KILL_NAMES = (
+    "assistantd",
+    "generativeexperiencesd",
+    "cfprefsd",
+)
+
+
+@dataclass(frozen=True)
+class ConsoleContext:
+    user: str
+    uid: int
+    gid: int
+    home: pathlib.Path
+
+    @property
+    def cache_path(self) -> pathlib.Path:
+        return self.home / CLOUDSUB_CACHE_REL
+
+    @property
+    def waitlist_path(self) -> pathlib.Path:
+        return self.home / CLOUDSUB_WAITLIST_REL
+
+    @property
+    def user_gms_path(self) -> pathlib.Path:
+        return self.home / GMS_AVAILABILITY_REL
+
+    @property
+    def platform_gms_path(self) -> pathlib.Path:
+        return AI_PLATFORM_PREFS_BASE / str(self.uid) / "Library/Preferences/com.apple.gms.availability.plist"
+
+    @property
+    def byhost_dir(self) -> pathlib.Path:
+        return self.home / BYHOST_REL
+
+    @property
+    def default_backup_root(self) -> pathlib.Path:
+        stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+        return self.home / BACKUP_REL / stamp
+
+    @property
+    def byhost_paths(self) -> list[pathlib.Path]:
+        return sorted(self.byhost_dir.glob(".GlobalPreferences.*.plist"))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Repair macOS 27 Enhanced Siri cloud cache and GMS state."
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--status", action="store_true", help="Print current health and exit.")
+    mode.add_argument("--repair-now", action="store_true", help="Force a repair run even if state looks healthy.")
+    mode.add_argument(
+        "--repair-if-needed",
+        action="store_true",
+        help="Repair only when ai.enhanced-siri or related GMS state regressed.",
+    )
+    parser.add_argument("--backup-root", help="Use this exact backup directory when a repair runs.")
+    parser.add_argument("--dry-run", action="store_true", help="Show whether a repair would run without writing files.")
+    parser.add_argument("--quiet", action="store_true", help="Suppress healthy/no-console chatter.")
+    args = parser.parse_args()
+    if not (args.status or args.repair_now or args.repair_if_needed):
+        args.repair_if_needed = True
+    return args
+
+
+def log(message: str, quiet: bool = False) -> None:
+    if not quiet:
+        print(message)
+
+
+def warn(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def now_utc() -> dt.datetime:
+    return dt.datetime.utcnow()
+
+
+def now_cfabsolute() -> float:
+    return time.time() - CF_ABSOLUTE_EPOCH
+
+
+def decode_blob(raw):
+    if isinstance(raw, (bytes, bytearray)):
+        for parser in (plistlib.loads, lambda blob: json.loads(blob.decode("utf-8"))):
+            try:
+                return parser(raw)
+            except Exception:
+                pass
+    return raw
+
+
+def encode_plist_blob(value) -> bytes:
+    return plistlib.dumps(value, fmt=plistlib.FMT_BINARY)
+
+
+def encode_json_blob(value) -> bytes:
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def load_plist(path: pathlib.Path):
+    if not path.exists():
+        return {}
+    with path.open("rb") as fh:
+        return plistlib.load(fh)
+
+
+def write_plist(path: pathlib.Path, data, owner: tuple[int, int] | None = None, default_mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".codex-tmp")
+    with tmp.open("wb") as fh:
+        plistlib.dump(data, fh, fmt=plistlib.FMT_BINARY, sort_keys=False)
+    if path.exists():
+        st = path.stat()
+        os.chown(tmp, st.st_uid, st.st_gid)
+        os.chmod(tmp, stat.S_IMODE(st.st_mode))
+    else:
+        target_uid, target_gid = owner if owner is not None else (0, 0)
+        os.chown(tmp, target_uid, target_gid)
+        os.chmod(tmp, default_mode)
+    os.replace(tmp, path)
+
+
+def backup_file(path: pathlib.Path, backup_root: pathlib.Path) -> None:
+    if not path.exists():
+        return
+    target = backup_root / path.relative_to(pathlib.Path("/"))
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(path, target)
+
+
+def donor_cache_entry(cache: dict) -> dict:
+    if not isinstance(cache, dict):
+        return {}
+    preferred_keys = (
+        "ai.enhanced-siri",
+        "cloud.llm.v2",
+        "cloud.llm",
+        "ai.apps.image-playground",
+    )
+    for key in preferred_keys:
+        entry = decode_blob(cache.get(key))
+        if isinstance(entry, dict):
+            return entry
+    for raw in cache.values():
+        entry = decode_blob(raw)
+        if isinstance(entry, dict):
+            return entry
+    return {}
+
+
+def console_context() -> ConsoleContext | None:
+    try:
+        uid = os.stat("/dev/console").st_uid
+        pw = pwd.getpwuid(uid)
+    except Exception:
+        return None
+    if uid == 0 or pw.pw_name in {"root", "loginwindow"}:
+        return None
+    return ConsoleContext(
+        user=pw.pw_name,
+        uid=uid,
+        gid=pw.pw_gid,
+        home=pathlib.Path(pw.pw_dir),
+    )
+
+
+def state_snapshot(ctx: ConsoleContext) -> dict:
+    cache = load_plist(ctx.cache_path)
+    waitlist = load_plist(ctx.waitlist_path)
+    user_gms = load_plist(ctx.user_gms_path)
+    platform_gms = load_plist(ctx.platform_gms_path)
+    byhost_states = []
+    for path in ctx.byhost_paths:
+        try:
+            data = load_plist(path)
+        except Exception:
+            data = {}
+        byhost_states.append(
+            {
+                "path": path,
+                "availability": data.get("com.apple.gms.enhancedSiri.availability") if isinstance(data, dict) else None,
+                "reasons": data.get("com.apple.gms.enhancedSiri.reasons") if isinstance(data, dict) else None,
+                "denied_use_cases": data.get("com.apple.gms.availability.accessNotGrantedUseCases") if isinstance(data, dict) else None,
+                "unified_reasons": decode_blob(data.get("com.apple.gms.availability.unifiedReasons")) if isinstance(data, dict) else None,
+            }
+        )
+
+    cache_entry = decode_blob(cache.get("ai.enhanced-siri")) if isinstance(cache, dict) else None
+    cache_value = cache_entry.get("value", {}) if isinstance(cache_entry, dict) else {}
+    waitlist_results = decode_blob(waitlist.get("waitlistResults", b"[]")) if isinstance(waitlist, dict) else []
+
+    waitlist_status = None
+    if isinstance(waitlist_results, list):
+        for item in waitlist_results:
+            value = item.get("value", {}) if isinstance(item, dict) else {}
+            if "ai.enhanced-siri" in (value.get("featureIDs") or []):
+                waitlist_status = value.get("status")
+                break
+
+    user_unified = decode_blob(user_gms.get("com.apple.gms.enhancedSiri.unifiedReasons")) if isinstance(user_gms, dict) else None
+    platform_denied = platform_gms.get("com.apple.gms.availability.accessNotGrantedUseCases") if isinstance(platform_gms, dict) else None
+    platform_unified = decode_blob(platform_gms.get("com.apple.gms.availability.unifiedReasons")) if isinstance(platform_gms, dict) else None
+
+    problems = []
+    if cache_value.get("canUse") is not True:
+        problems.append("cloud cache denies ai.enhanced-siri")
+    if waitlist_status != "active":
+        problems.append(f"waitlist status is {waitlist_status!r}")
+    if user_unified not in (None, []):
+        problems.append(f"user unifiedReasons is {user_unified!r}")
+    if platform_denied not in (None, []):
+        problems.append(f"platform denied use cases is {platform_denied!r}")
+    if platform_unified not in (None, {}):
+        problems.append(f"platform unifiedReasons is {platform_unified!r}")
+    for entry in byhost_states:
+        if entry["availability"] is not True:
+            problems.append(f"{entry['path'].name} availability is {entry['availability']!r}")
+        if entry["reasons"] not in (None, []):
+            problems.append(f"{entry['path'].name} reasons is {entry['reasons']!r}")
+        if entry["denied_use_cases"] not in (None, []):
+            problems.append(f"{entry['path'].name} denied use cases is {entry['denied_use_cases']!r}")
+        if entry["unified_reasons"] not in (None, {}):
+            problems.append(f"{entry['path'].name} unifiedReasons is {entry['unified_reasons']!r}")
+
+    return {
+        "cache": cache,
+        "waitlist": waitlist,
+        "user_gms": user_gms,
+        "platform_gms": platform_gms,
+        "cache_entry": cache_entry if isinstance(cache_entry, dict) else {},
+        "cache_value": cache_value if isinstance(cache_value, dict) else {},
+        "waitlist_results": waitlist_results if isinstance(waitlist_results, list) else [],
+        "waitlist_status": waitlist_status,
+        "user_unified": user_unified,
+        "platform_denied": platform_denied,
+        "platform_unified": platform_unified,
+        "byhost_states": byhost_states,
+        "problems": problems,
+    }
+
+
+def print_snapshot(ctx: ConsoleContext, snapshot: dict) -> None:
+    print(f"console user: {ctx.user} ({ctx.uid})")
+    print(f"cache ai.enhanced-siri canUse: {snapshot['cache_value'].get('canUse')!r}")
+    print(f"waitlist status: {snapshot['waitlist_status']!r}")
+    print(f"user unifiedReasons: {snapshot['user_unified']!r}")
+    print(f"platform denied use cases: {snapshot['platform_denied']!r}")
+    print(f"platform unifiedReasons: {snapshot['platform_unified']!r}")
+    if snapshot["byhost_states"]:
+        for entry in snapshot["byhost_states"]:
+            print(
+                f"{entry['path'].name}: availability={entry['availability']!r} "
+                f"reasons={entry['reasons']!r} denied={entry['denied_use_cases']!r}"
+            )
+    else:
+        print("ByHost GlobalPreferences: none found")
+    if snapshot["problems"]:
+        print("state: degraded")
+        for problem in snapshot["problems"]:
+            print(f"- {problem}")
+    else:
+        print("state: healthy")
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+
+
+def restart_runtime(ctx: ConsoleContext) -> None:
+    for name in KILL_NAMES:
+        run(["/usr/bin/killall", name])
+    for notification in NOTIFY_NAMES:
+        run(["/bin/launchctl", "asuser", str(ctx.uid), "/usr/bin/notifyutil", "-p", notification])
+    for label, plist in GUI_LAUNCH_AGENTS:
+        run(["/bin/launchctl", "bootstrap", f"gui/{ctx.uid}", plist])
+        run(["/bin/launchctl", "kickstart", "-k", f"gui/{ctx.uid}/{label}"])
+
+
+def apply_repair(ctx: ConsoleContext, snapshot: dict, backup_root: pathlib.Path, dry_run: bool) -> dict:
+    cache = snapshot["cache"] if isinstance(snapshot["cache"], dict) else {}
+    waitlist = snapshot["waitlist"] if isinstance(snapshot["waitlist"], dict) else {}
+    user_gms = snapshot["user_gms"] if isinstance(snapshot["user_gms"], dict) else {}
+    platform_gms = snapshot["platform_gms"] if isinstance(snapshot["platform_gms"], dict) else {}
+
+    donor = donor_cache_entry(cache)
+    donor_value = donor.get("value", {}) if isinstance(donor.get("value"), dict) else {}
+    cache_entry = snapshot["cache_entry"] if isinstance(snapshot["cache_entry"], dict) else {}
+    cache_value = cache_entry.get("value", {})
+    if not isinstance(cache_value, dict):
+        cache_value = {}
+
+    now = now_utc()
+    cf_now = now_cfabsolute()
+    cache_till = (
+        cache_value.get("cacheTill")
+        or donor_value.get("cacheTill")
+        or cache_entry.get("expiration")
+        or donor.get("expiration")
+        or (now + dt.timedelta(days=1))
+    )
+    cache_value["featureKey"] = "ai.enhanced-siri"
+    cache_value["canUse"] = True
+    cache_value["cacheTill"] = cache_till
+    cache_entry["value"] = cache_value
+    cache_entry["expiration"] = cache_entry.get("expiration") or cache_till
+    cache_entry["fetched"] = now
+    session_id = cache_entry.get("sessionID") or donor.get("sessionID")
+    alt_dsid = cache_entry.get("altDSID") or donor.get("altDSID")
+    if session_id:
+        cache_entry["sessionID"] = session_id
+    if alt_dsid:
+        cache_entry["altDSID"] = alt_dsid
+    cache["ai.enhanced-siri"] = encode_plist_blob(cache_entry)
+
+    waitlist_results = snapshot["waitlist_results"] if isinstance(snapshot["waitlist_results"], list) else []
+    matched_item = None
+    for item in waitlist_results:
+        value = item.get("value", {}) if isinstance(item, dict) else {}
+        if "ai.enhanced-siri" in (value.get("featureIDs") or []):
+            matched_item = item
+            break
+    if matched_item is None:
+        matched_item = {}
+        waitlist_results.append(matched_item)
+    matched_value = matched_item.get("value", {})
+    if not isinstance(matched_value, dict):
+        matched_value = {}
+    matched_value["featureIDs"] = ["ai.enhanced-siri"]
+    matched_value["status"] = "active"
+    matched_item["value"] = matched_value
+    matched_item["dirty"] = False
+    boot_uuid = (
+        matched_item.get("bootSessionID")
+        or session_id
+        or user_gms.get("com.apple.gms.availability.updatedSinceBootUUID")
+        or user_gms.get("com.apple.gms.enhancedSiri.bootUUID")
+    )
+    if boot_uuid:
+        matched_item["bootSessionID"] = boot_uuid
+    if alt_dsid:
+        matched_item["altDSID"] = alt_dsid
+    matched_item["fetched"] = cf_now
+    waitlist["waitlistResults"] = encode_json_blob(waitlist_results)
+
+    user_gms["com.apple.gms.availability.reasons"] = []
+    user_gms["com.apple.gms.availability.wasAvailable"] = True
+    user_gms["com.apple.gms.availability.lastCheckedReadiness"] = now
+    user_gms["com.apple.gms.availability.lastReadinessChange"] = now
+    user_gms["com.apple.gms.availability.lastUpdateStarted"] = now
+    user_gms["com.apple.gms.availability.lastUpdateEnded"] = now
+    user_gms["com.apple.gms.availability.lastUpdateChanged"] = True
+    latest_notifications = decode_blob(user_gms.get("com.apple.gms.availability.latestNotifications"))
+    if isinstance(latest_notifications, dict):
+        latest_notifications[".force"] = now
+        latest_notifications[".notification(com.apple.siri.orchestration.capabilities.didChange, type: .normal)"] = now
+        user_gms["com.apple.gms.availability.latestNotifications"] = encode_plist_blob(latest_notifications)
+    if boot_uuid:
+        user_gms["com.apple.gms.availability.updatedSinceBootUUID"] = boot_uuid
+        user_gms["com.apple.gms.enhancedSiri.bootUUID"] = boot_uuid
+    user_gms["com.apple.gms.availability.accessNotGrantedUseCases"] = []
+    user_gms["com.apple.gms.enhancedSiri.unifiedReasons"] = b"[]"
+    user_gms["com.apple.gms.enhancedSiri.wasEverAvailable"] = True
+
+    platform_gms["com.apple.gms.availability.accessNotGrantedUseCases"] = []
+    platform_gms["com.apple.gms.availability.reasons"] = []
+    platform_gms["com.apple.gms.availability.unifiedReasons"] = b"{}"
+
+    patched_byhost = 0
+    byhost_payloads: list[tuple[pathlib.Path, dict]] = []
+    for entry in snapshot["byhost_states"]:
+        path = entry["path"]
+        byhost = load_plist(path)
+        if not isinstance(byhost, dict):
+            byhost = {}
+        byhost["com.apple.gms.availability.accessNotGrantedUseCases"] = []
+        byhost["com.apple.gms.availability.unifiedReasons"] = b"{}"
+        byhost["com.apple.gms.enhancedSiri.availability"] = True
+        byhost["com.apple.gms.enhancedSiri.reasons"] = []
+        byhost["com.apple.gms.enhancedSiri.lastUpdated"] = now
+        byhost_payloads.append((path, byhost))
+        patched_byhost += 1
+
+    if dry_run:
+        return {
+            "backup_root": backup_root,
+            "patched_byhost": patched_byhost,
+            "session_id": session_id,
+            "alt_dsid": alt_dsid,
+        }
+
+    backup_root.mkdir(parents=True, exist_ok=True)
+    for path in (ctx.cache_path, ctx.waitlist_path, ctx.user_gms_path, ctx.platform_gms_path):
+        backup_file(path, backup_root)
+    for path, _payload in byhost_payloads:
+        backup_file(path, backup_root)
+
+    write_plist(ctx.cache_path, cache, owner=(ctx.uid, ctx.gid))
+    write_plist(ctx.waitlist_path, waitlist, owner=(ctx.uid, ctx.gid))
+    write_plist(ctx.user_gms_path, user_gms, owner=(ctx.uid, ctx.gid))
+    write_plist(ctx.platform_gms_path, platform_gms)
+    for path, payload in byhost_payloads:
+        write_plist(path, payload, owner=(ctx.uid, ctx.gid))
+
+    restart_runtime(ctx)
+    return {
+        "backup_root": backup_root,
+        "patched_byhost": patched_byhost,
+        "session_id": session_id,
+        "alt_dsid": alt_dsid,
+    }
+
+
+def ensure_root_for_write(dry_run: bool) -> None:
+    if dry_run:
+        return
+    if os.geteuid() != 0:
+        raise PermissionError("repair mode must run as root; use sudo or the installed LaunchDaemon")
+
+
+def main() -> int:
+    args = parse_args()
+    ctx = console_context()
+    if ctx is None:
+        log("No console user; skipping Enhanced Siri repair.", quiet=args.quiet)
+        return 0
+
+    LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with LOCK_PATH.open("a+") as lock_fh:
+        try:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            log("Enhanced Siri repair is already running; skipping.", quiet=args.quiet)
+            return 0
+
+        snapshot = state_snapshot(ctx)
+        if args.status:
+            print_snapshot(ctx, snapshot)
+            return 0 if not snapshot["problems"] else 1
+
+        try:
+            ensure_root_for_write(args.dry_run)
+        except PermissionError as exc:
+            warn(str(exc))
+            return 2
+
+        needs_repair = args.repair_now or bool(snapshot["problems"])
+        if not needs_repair:
+            log("Enhanced Siri state already healthy; no repair needed.", quiet=args.quiet)
+            return 0
+
+        backup_root = pathlib.Path(args.backup_root).expanduser() if args.backup_root else ctx.default_backup_root
+        repair_snapshot = copy.deepcopy(snapshot) if args.dry_run else snapshot
+        result = apply_repair(ctx, repair_snapshot, backup_root, dry_run=args.dry_run)
+
+        if args.dry_run:
+            print_snapshot(ctx, snapshot)
+            print("repairNeeded: True")
+            print(f"backup root: {result['backup_root']}")
+            print(f"patchedByHost: {result['patched_byhost']}")
+            return 0
+
+        repaired = state_snapshot(ctx)
+        print(f"repairApplied: True")
+        print(f"backup root: {result['backup_root']}")
+        print(f"patchedByHost: {result['patched_byhost']}")
+        print(f"sessionID: {result['session_id']!r}")
+        print(f"altDSID: {result['alt_dsid']!r}")
+        print_snapshot(ctx, repaired)
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
macOS 27 beta 2 introduced a new regression where new Siri AI can fall back because Apple appears to have added new network-backed checks that re-validate Enhanced Siri cloud entitlement, waitlist state, and related GMS availability

Parts of the investigation and write-up for this fix were AI-assisted, so please do not judge it too harshly as polished production code; this is mostly an experimental workaround based on observed behavior, but so far it seems to work well enough in practice.