### PR TITLE
Fix country-of-origin=USA false negative in status check

### DIFF
--- a/enable_apple_intelligence_oneclick.sh
+++ b/enable_apple_intelligence_oneclick.sh
@@ -322,8 +322,10 @@ root_region_is_spoofed() {
 }
 
 country_origin_is_usa() {
+  # ioreg renders country-of-origin either as hex (555341) or as the ASCII
+  # string <"USA"> depending on padding; match both to avoid a false negative.
   /usr/sbin/ioreg -rd1 -c IOPlatformExpertDevice 2>/dev/null |
-    /usr/bin/grep -qi '555341'
+    /usr/bin/grep -qi '555341\|"USA"'
 }
 
 yes_no() {


### PR DESCRIPTION
## Problem
`--verify-only` reports `country-of-origin=USA: no` even when the kext spoof is active and the IORegistry value is correct.

On affected machines, `ioreg` renders the property as the ASCII string `<"USA">` (unpadded), not as hex `555341`. The existing grep only matches the hex form, so it always misses, producing a false negative. (`region-info` is unaffected because its trailing zero padding forces hex rendering, matching `4c4c2f41`.)

## Fix
Match both renderings: `grep -qi '555341\\|"USA"'`.

Verified locally: kext loaded, `region-info=LL/A`, ioreg shows `country-of-origin = <"USA">`, status now reports `yes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)