### PR TITLE
Clear schg as well as uchg in unlock_file

### DIFF
--- a/enable_apple_intelligence_oneclick.sh
+++ b/enable_apple_intelligence_oneclick.sh
@@ -408,7 +408,10 @@ ensure_plist_file() {
 }
 
 unlock_file() {
-  [[ -e "$1" ]] && /usr/bin/chflags nouchg "$1" 2>/dev/null || true
+  # Clear both user- and system-immutable flags. Some system caches (e.g.
+  # countryd's countryCodeCache.plist) ship with schg, which nouchg alone
+  # cannot remove; without this the plist rewrite fails with EPERM.
+  [[ -e "$1" ]] && /usr/bin/chflags nouchg,noschg "$1" 2>/dev/null || true
 }
 
 lock_file_eligibility() {


### PR DESCRIPTION
## What changed

`unlock_file()` now runs `chflags nouchg,noschg` instead of `chflags nouchg`.

## Why

Several of the caches this script rewrites carry the **system**-immutable flag (`schg`), not just the user-immutable one (`uchg`). countryd's `countryCodeCache.plist` is the concrete case.

`chflags nouchg` does not clear `schg`, so the flag survived, the subsequent plist rewrite failed with `EPERM`, and the cached country code was left at its old value. Because `unlock_file` ends in `|| true` and the write path does not check, this failed silently — the script reported success while `--force-geoservices-us` / countryd pinning had no effect.

Clearing both flags fixes the rewrite. A comment records the reason so the flag pair is not trimmed back to `nouchg` later.

## Notes for reviewers

- Behaviour is unchanged for files that only carry `uchg`; `noschg` is a no-op there.
- `noschg` requires root, which the script already ensures — it re-execs itself under `sudo` before any of these paths run.
- Scope is one function; no callers changed.